### PR TITLE
fix: panic on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "curl-rest"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace72c9b4bd7fd7df583958d0a302792ca1823dff8c7f70c615a644ea8fad198"
+checksum = "be2164c11b86717a266f9921d75ea94d486b832920b978cb7c557dc0a2f2cbf2"
 dependencies = [
  "curl",
  "percent-encoding",

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -30,12 +30,8 @@ impl<'a> App<'a> {
             if event::poll(Duration::from_millis(50)).unwrap() {
                 let event = event::read().unwrap();
                 match event {
-                    event::Event::FocusGained => todo!(),
-                    event::Event::FocusLost => todo!(),
                     event::Event::Key(key_event) => self.handle_key_events(key_event),
-                    event::Event::Mouse(_mouse_event) => todo!(),
-                    event::Event::Paste(_) => todo!(),
-                    event::Event::Resize(_, _) => todo!(),
+                    _ => (),
                 }
             }
 


### PR DESCRIPTION
This panic was likey cause by on resize event being triggered on Windows. I have ignored all the other event types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Optimised internal event handling logic for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->